### PR TITLE
登録画面での「登録」ボタンが、テキストボックスが空の時にdisabledになるようにしました

### DIFF
--- a/client/src/pages/WordAdd.vue
+++ b/client/src/pages/WordAdd.vue
@@ -31,9 +31,7 @@ const newWord = ref('')
 apiClient.list.getListUserMe().then((res) => (words.value = res))
 
 const registerNewWord = () => {
-  if (newWord.value.length == 0) {
-    return
-  } else if (newWord.value.length > 50) {
+  if (newWord.value.length > 50) {
     openFailedDialog()
     return
   }
@@ -88,7 +86,7 @@ const updateNewSelfNotify = (newValue: boolean) => {
     <SelfNotify @updete-self-notify="(newValue) => updateNewSelfNotify(newValue)" />
   </div>
   <div class="registerButton mb-16 mt-4">
-    <button @click="registerNewWord">登録</button>
+    <v-btn :disabled="newWord===''" @click="registerNewWord">登録</v-btn>
   </div>
 
   <div class="table">
@@ -233,8 +231,5 @@ p {
   min-width: 10em;
   max-width: 100%;
   padding: 1.2em;
-}
-.regiserButton {
-  display: flex;
 }
 </style>

--- a/client/src/pages/WordAdd.vue
+++ b/client/src/pages/WordAdd.vue
@@ -31,9 +31,9 @@ const newWord = ref('')
 apiClient.list.getListUserMe().then((res) => (words.value = res))
 
 const registerNewWord = () => {
-  if (newWord.value.length===0){
+  if (newWord.value.length === 0) {
     return
-  }else if (newWord.value.length > 50) {
+  } else if (newWord.value.length > 50) {
     openFailedDialog()
     return
   }

--- a/client/src/pages/WordAdd.vue
+++ b/client/src/pages/WordAdd.vue
@@ -86,11 +86,11 @@ const updateNewSelfNotify = (newValue: boolean) => {
     <SelfNotify @updete-self-notify="(newValue) => updateNewSelfNotify(newValue)" />
   </div>
   <div class="registerButton mb-16 mt-4">
-    <v-btn :disabled="newWord===''" @click="registerNewWord">登録</v-btn>
+    <v-btn :disabled="newWord === ''" @click="registerNewWord">登録</v-btn>
   </div>
 
   <div class="table">
-    <table class="wordList ">
+    <table class="wordList">
       <tr>
         <th class="">単語</th>
         <th class="">bot通知</th>

--- a/client/src/pages/WordAdd.vue
+++ b/client/src/pages/WordAdd.vue
@@ -31,7 +31,9 @@ const newWord = ref('')
 apiClient.list.getListUserMe().then((res) => (words.value = res))
 
 const registerNewWord = () => {
-  if (newWord.value.length > 50) {
+  if (newWord.value.length===0){
+    return
+  }else if (newWord.value.length > 50) {
     openFailedDialog()
     return
   }

--- a/client/src/pages/WordList.vue
+++ b/client/src/pages/WordList.vue
@@ -51,7 +51,7 @@ const deleteWord = () => {
     <h1>登録単語の閲覧ページ</h1>
   </div>
   <div class="table">
-    <table class="wordList ">
+    <table class="wordList">
       <tr>
         <th class="">単語</th>
         <th class="">bot通知</th>

--- a/client/src/style.css
+++ b/client/src/style.css
@@ -55,6 +55,25 @@ button:focus-visible {
   outline: 4px auto -webkit-focus-ring-color;
 }
 
+v-btn {
+  border-radius: 8px;
+  border: 1px solid transparent;
+  padding: 0.6em 1.2em;
+  font-size: 1em;
+  font-weight: 500;
+  font-family: inherit;
+  background-color: #1a1a1a;
+  cursor: pointer;
+  transition: border-color 0.25s;
+}
+v-btn:hover {
+  border-color: #646cff;
+}
+v-btn:focus,
+v-btn:focus-visible {
+  outline: 4px auto -webkit-focus-ring-color;
+}
+
 .card {
   padding: 2em;
 }


### PR DESCRIPTION
hTML標準のボタンでは、if文を内包してdisabledにすることができませんでした。
したがって、今回はvueに入っているv-btnを用いて実装しました。
これに伴い、buttonのstyleをv-btn用に複製してあります。