### PR TITLE
time zoneが動かない

### DIFF
--- a/dockerfiles/prod.Dockerfile
+++ b/dockerfiles/prod.Dockerfile
@@ -30,6 +30,10 @@ FROM alpine:3.18.2
 
 WORKDIR /
 
+RUN apk add --update --no-cache ca-certificates tzdata && update-ca-certificates \
+    && cp /usr/share/zoneinfo/Asia/Tokyo /etc/localtime \
+    && rm -rf /usr/share/zoneinfo
+
 COPY --from=client-build /app/dist dist
 COPY --from=server-build /github.com/traP-jp/h23s_15/app app
 


### PR DESCRIPTION
#106 
trendのAPIが
`2023/07/02 16:33:23 INFO Error GetTrendOneday LoadLocation: %v !BADKEY="unknown time zone Asia/Tokyo"`
と言われ動かない問題を修正しようとしているが、解決方法が見つからない。